### PR TITLE
Follow-up: guard Streamlit secrets and sanitize predictive features

### DIFF
--- a/app.py
+++ b/app.py
@@ -91,6 +91,7 @@ def build_predictive_features(data: pd.DataFrame) -> pd.DataFrame:
     df["sentiment_change"] = df["avg_sentiment"].diff().fillna(0)
     df["volume_change"] = df["Volume"].pct_change().fillna(0)
     df["target_return"] = df["return"].shift(-1)
+    df = df.replace([np.inf, -np.inf], np.nan)
     df = df.dropna(subset=["return", "sentiment_change", "volume_change", "target_return", "avg_sentiment"])
     return df
 
@@ -252,8 +253,16 @@ start_dt = datetime.combine(start_date, datetime.min.time())
 end_dt = datetime.combine(end_date, datetime.max.time())
 
 try:
-    newsapi_key = st.secrets.get("newsapi_key")
+    secrets = st.secrets
 except Exception:
+    secrets = None
+
+if secrets is not None:
+    try:
+        newsapi_key = secrets.get("newsapi_key")
+    except Exception:
+        newsapi_key = None
+else:
     newsapi_key = None
 
 newsapi_key = newsapi_key or os.getenv("NEWSAPI_KEY", "")


### PR DESCRIPTION
### Motivation
- Prevent the app from crashing when a Streamlit `secrets.toml` is missing so the NewsAPI key can fall back to environment variables. 
- Avoid training-time errors in the predictive model caused by `NaN`/`inf` values produced by `pct_change()` and `shift()` during feature construction.

### Description
- Safely access `st.secrets` by catching exceptions and reading `newsapi_key` via `secrets.get()` with a fallback to `os.getenv("NEWSAPI_KEY")` in `app.py`.
- Sanitize predictive features in `build_predictive_features` by replacing `np.inf`/`-np.inf` with `NaN` and dropping rows with missing values before returning the feature DataFrame.
- All changes were made in `app.py` to ensure the dashboard can launch without a `secrets.toml` and the model fitting step skips invalid rows.

### Testing
- No automated tests were executed for this follow-up change.
- Changes were committed locally and are ready for CI or manual verification in the running app.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69608397a770832cb4637e0e1c32a8d9)